### PR TITLE
Set default body object before checking status

### DIFF
--- a/lib/discourse.js
+++ b/lib/discourse.js
@@ -50,6 +50,7 @@ Discourse.prototype.get = function(url, parameters, callback) {
       json: true
     },
     function(error, response, body) {
+      body = body || {};
 
       if (error) {
         callback(error, {}, 500);
@@ -58,7 +59,7 @@ Discourse.prototype.get = function(url, parameters, callback) {
         error = new Error(body.description || body.error_message);
       }
 
-      callback(error, body || {}, response != null ? response.statusCode : null);
+      callback(error, body, response != null ? response.statusCode : null);
 
     }
   );


### PR DESCRIPTION
@JonForest I decided to just fix this, given I had the failing situation present at the time.

They were already defaulting the body to an empty object further down, so I decided not to alter the output expectations and just default earlier, before checking for attributes on that undefined body in the error case.
